### PR TITLE
Issue 2959309; Case 29516; undefined function base_path() - 8.x-1.x

### DIFF
--- a/domain/src/Entity/Domain.php
+++ b/domain/src/Entity/Domain.php
@@ -271,14 +271,16 @@ class Domain extends ConfigEntityBase implements DomainInterface {
    * {@inheritdoc}
    */
   public function setPath() {
-    $this->path = $this->getScheme() . $this->getHostname() . base_path();
+    global $base_path;
+    $this->path = $this->getScheme() . $this->getHostname() . ($base_path ?: '/');
   }
 
   /**
    * {@inheritdoc}
    */
   public function setUrl() {
-    $uri = \Drupal::request()->getRequestUri();
+    $request = \Drupal::request();
+    $uri = $request ? $request->getRequestUri() : '/';
     $this->url = $this->getScheme() . $this->getHostname() . $uri;
   }
 

--- a/domain/src/Entity/Domain.php
+++ b/domain/src/Entity/Domain.php
@@ -271,14 +271,15 @@ class Domain extends ConfigEntityBase implements DomainInterface {
    * {@inheritdoc}
    */
   public function setPath() {
-    $this->path = $this->getScheme() . $this->getHostname() . base_path();
+    $this->path = $this->getScheme() . $this->getHostname() . $GLOBALS['base_path'];
   }
 
   /**
    * {@inheritdoc}
    */
   public function setUrl() {
-    $uri = \Drupal::request()->getRequestUri();
+    $request = \Drupal::request();
+    $uri = $request ? $request->getRequestUri() : '/';
     $this->url = $this->getScheme() . $this->getHostname() . $uri;
   }
 


### PR DESCRIPTION
Merged latest 8.x-1.x branch to the latest version.
Patch 1: https://www.drupal.org/project/domain/issues/2951511
Patch 2: 
```
-    $this->path = $this->getScheme() . $this->getHostname() . base_path();
+    $this->path = $this->getScheme() . $this->getHostname() . $GLOBALS['base_path'];
```